### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 Model Context Protocol (MCP) Server for the JFrog Platform API, enabling repository management, build tracking, release lifecycle management, and more.
 
+<a href="https://glama.ai/mcp/servers/@jfrog/mcp-jfrog">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jfrog/mcp-jfrog/badge" alt="JFrog Server MCP server" />
+</a>
 
 https://github.com/user-attachments/assets/aca3af2b-f294-41c8-8727-799a019a55b5
 
@@ -525,7 +528,6 @@ For Claude Desktop with SSE transport:
     }
   }
 }
-```
 ```
 </details>
 


### PR DESCRIPTION
This PR adds a badge for the [JFrog MCP Server](https://glama.ai/mcp/servers/@jfrog/mcp-jfrog) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@jfrog/mcp-jfrog">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jfrog/mcp-jfrog/badge" alt="JFrog Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.